### PR TITLE
Add helper to flush OpenTelemetry data

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -7,7 +7,7 @@ import { put } from '@vercel/blob';
 import { nanoid } from '@/utils/utils';
 import { SpanStatusCode, Span } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
-import { logger, tracer, meter } from '@/otel-server';
+import { logger, tracer, meter, flushOtel } from '@/otel-server';
 
 // Initialize metrics
 const requestCounter = meter.createCounter('qr_generation_requests_total', {
@@ -303,6 +303,7 @@ export async function POST(request: NextRequest) {
 
       return new Response('Internal Server Error', { status: 500 });
     } finally {
+      await flushOtel();
       span.end();
     }
   });

--- a/otel-server.ts
+++ b/otel-server.ts
@@ -73,6 +73,19 @@ export const logger = logs.getLogger(serviceName);
 export const tracer = trace.getTracer(serviceName);
 export const meter = metrics.getMeter(serviceName);
 
+export async function flushOtel(): Promise<void> {
+  try {
+    await sdk.forceFlush();
+  } catch (error) {
+    logger.emit({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'ERROR',
+      body: 'Error flushing OpenTelemetry SDK',
+      attributes: { error: (error as Error).message },
+    });
+  }
+}
+
 // Initialize OpenTelemetry and return initialized components
 export function initOtel() {
   try {


### PR DESCRIPTION
## Summary
- add an exported helper that forces the OpenTelemetry SDK to flush and logs failures
- ensure the generate API route awaits the flush helper so buffered telemetry is sent before finishing requests

## Testing
- `npm run lint` *(fails: components/Body.tsx unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5b6c32cc832aaecc674749ba03ef